### PR TITLE
Remove reference in Makefile to removed log library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,6 @@ CFLAGS+= -I$(INC_INSTALL_DIR) \
     -DDSL_LOGGER_IMP='"DslLogGst.h"'
 
 LIBS+= -L$(LIB_INSTALL_DIR) \
-	-llog4cxx  \
 	-laprutil-1 \
 	-lapr-1 \
 	-lX11 \


### PR DESCRIPTION
Since I did not install the log4cxx stuff the makefile would error out when I tried to build the target.  Removing the reference allows it to build.