### PR TITLE
Complete RTSP Sink implementation

### DIFF
--- a/dsl.py
+++ b/dsl.py
@@ -14,8 +14,8 @@ DSL_CODEC_H264 = 0
 DSL_CODEC_H265 = 1
 DSL_CODEC_MPEG4 = 2
 
-DSL_MUXER_MPEG4 = 0
-DSL_MUXER_MK4 = 1
+DSL_CONTAINER_MPEG4 = 0
+DSL_CONTAINER_MK4 = 1
 
 ##
 ## Pointer Typedefs
@@ -132,34 +132,34 @@ def dsl_source_is_live(name):
 #print(dsl_source_is_live("uri-source"))
 
 ##
-## dsl_source_get_num_in_use()
+## dsl_source_num_in_use_get()
 ##
-_dsl.dsl_source_get_num_in_use.restype = c_uint
-def dsl_source_get_num_in_use():
+_dsl.dsl_source_num_in_use_get.restype = c_uint
+def dsl_source_num_in_use_get():
     global _dsl
-    result = _dsl.dsl_source_get_num_in_use()
+    result = _dsl.dsl_source_num_in_use_get()
     return int(result)
-#print(dsl_source_get_num_in_use())
+#print(dsl_source_num_in_use_get())
 
 ##
-## dsl_source_get_num_in_use_max()
+## dsl_source_num_in_use_max_get()
 ##
-_dsl.dsl_source_get_num_in_use_max.restype = c_uint
-def dsl_source_get_num_in_use_max():
+_dsl.dsl_source_num_in_use_max_get.restype = c_uint
+def dsl_source_num_in_use_max_get():
     global _dsl
-    result = _dsl.dsl_source_get_num_in_use_max()
+    result = _dsl.dsl_source_num_in_use_max_get()
     return int(result)
-#print(dsl_source_get_num_in_use_max())
+#print(dsl_source_num_in_use_max_get())
 
 ##
-## dsl_source_set_num_in_use_max()
+## dsl_source_num_in_use_max_set()
 ##
-_dsl.dsl_source_set_num_in_use_max.argtypes = [c_uint]
-def dsl_source_set_num_in_use_max(max):
+_dsl.dsl_source_num_in_use_max_set.argtypes = [c_uint]
+def dsl_source_num_in_use_max_set(max):
     global _dsl
-    result = _dsl.dsl_source_set_num_in_use_max(max)
-dsl_source_set_num_in_use_max(20)
-#print(dsl_source_get_num_in_use_max())
+    result = _dsl.dsl_source_num_in_use_max_set(max)
+dsl_source_num_in_use_max_set(20)
+#print(dsl_source_num_in_use_max_get())
 
 ##
 ## dsl_gie_primary_new()
@@ -401,7 +401,123 @@ def dsl_sink_file_new(name, filepath, codec, mutex, bitrate, interval):
     global _dsl
     result =_dsl.dsl_sink_file_new(name, filepath, codec, mutex, bitrate, interval)
     return int(result)
-#print(dsl_sink_file_new("file-sink", "./output.mp4", DSL_CODEC_H265, DSL_MUXER_MPEG4, 2000000, 1))
+
+##
+## dsl_sink_file_video_formats_get()
+##
+_dsl.dsl_sink_file_video_formats_get.argtypes = [c_wchar_p, POINTER(c_uint), POINTER(c_uint)]
+_dsl.dsl_sink_file_video_formats_get.restype = c_uint
+def dsl_sink_file_video_formats_get(name):
+    global _dsl
+    codec = c_uint(0)
+    container = c_uint(0)
+    result = _dsl.dsl_sink_file_video_formats_get(name, DSL_UINT_P(codec), DSL_UINT_P(container))
+    return int(result), codec.value, container.value 
+
+##
+## dsl_sink_file_encoder_settings_get()
+##
+_dsl.dsl_sink_file_encoder_settings_get.argtypes = [c_wchar_p, POINTER(c_uint), POINTER(c_uint)]
+_dsl.dsl_sink_file_encoder_settings_get.restype = c_uint
+def dsl_sink_file_encoder_settings_get(name):
+    global _dsl
+    bitrate = c_uint(0)
+    interval = c_uint(0)
+    result = _dsl.dsl_sink_file_encoder_settings_get(name, DSL_UINT_P(bitrate), DSL_UINT_P(interval))
+    return int(result), bitrate.value, interval.value 
+
+##
+## dsl_sink_file_encoder_settings_set()
+##
+_dsl.dsl_sink_file_encoder_settings_set.argtypes = [c_wchar_p, c_uint, c_uint]
+_dsl.dsl_sink_file_encoder_settings_set.restype = c_uint
+def dsl_sink_file_encoder_settings_set(name, bitrate, interval):
+    global _dsl
+    result = _dsl.dsl_sink_file_encoder_settings_set(name, bitrate, interval)
+    return int(result)
+#print(dsl_sink_file_new("file-sink", "./output.mp4", DSL_CODEC_H265, DSL_CONTAINER_MPEG4, 2000000, 1))
+#print(dsl_sink_file_video_formats_get("file-sink"))
+#print(dsl_sink_file_encoder_settings_get("file-sink"))
+#print(dsl_sink_file_encoder_settings_set("file-sink", 2500000, 5))
+
+##
+## dsl_sink_rtsp_new()
+##
+_dsl.dsl_sink_rtsp_new.argtypes = [c_wchar_p, c_wchar_p, c_uint, c_uint, c_uint, c_uint, c_uint]
+_dsl.dsl_sink_rtsp_new.restype = c_uint
+def dsl_sink_rtsp_new(name, host, udp_port, rtsp_port, codec, bitrate, interval):
+    global _dsl
+    result =_dsl.dsl_sink_rtsp_new(name, host, udp_port, rtsp_port, codec, bitrate, interval)
+    return int(result)
+
+##
+## dsl_sink_rtsp_server_settings_get()
+##
+_dsl.dsl_sink_rtsp_server_settings_get.argtypes = [c_wchar_p, POINTER(c_uint), POINTER(c_uint), POINTER(c_uint)]
+_dsl.dsl_sink_rtsp_server_settings_get.restype = c_uint
+def dsl_sink_rtsp_server_settings_get(name):
+    global _dsl
+    udp_port = c_uint(0)
+    rtsp_port = c_uint(0)
+    codec = c_uint(0)
+    result = _dsl.dsl_sink_rtsp_server_settings_get(name, DSL_UINT_P(udp_port), DSL_UINT_P(rtsp_port), DSL_UINT_P(codec))
+    return int(result), udp_port.value, rtsp_port.value, codec.value 
+
+##
+## dsl_sink_rtsp_encoder_settings_get()
+##
+_dsl.dsl_sink_rtsp_encoder_settings_get.argtypes = [c_wchar_p, POINTER(c_uint), POINTER(c_uint)]
+_dsl.dsl_sink_rtsp_encoder_settings_get.restype = c_uint
+def dsl_sink_rtsp_encoder_settings_get(name):
+    global _dsl
+    bitrate = c_uint(0)
+    interval = c_uint(0)
+    result = _dsl.dsl_sink_rtsp_encoder_settings_get(name, DSL_UINT_P(bitrate), DSL_UINT_P(interval))
+    return int(result), bitrate.value, interval.value 
+
+##
+## dsl_sink_rtsp_encoder_settings_set()
+##
+_dsl.dsl_sink_rtsp_encoder_settings_set.argtypes = [c_wchar_p, c_uint, c_uint]
+_dsl.dsl_sink_rtsp_encoder_settings_set.restype = c_uint
+def dsl_sink_rtsp_encoder_settings_set(name, bitrate, interval):
+    global _dsl
+    result = _dsl.dsl_sink_rtsp_encoder_settings_set(name, bitrate, interval)
+    return int(result)
+print(dsl_sink_rtsp_new("rtsp-sink", "224.224.255.255", 5400, 8554, DSL_CODEC_H265, 4000000, 0))
+print(dsl_sink_rtsp_server_settings_get("rtsp-sink"))
+print(dsl_sink_rtsp_encoder_settings_get("rtsp-sink"))
+print(dsl_sink_rtsp_encoder_settings_set("rtsp-sink", 4500000, 5))
+
+##
+## dsl_sink_num_in_use_get()
+##
+_dsl.dsl_sink_num_in_use_get.restype = c_uint
+def dsl_sink_num_in_use_get():
+    global _dsl
+    result = _dsl.dsl_sink_num_in_use_get()
+    return int(result)
+#print(dsl_sink_num_in_use_get())
+
+##
+## dsl_sink_num_in_use_max_get()
+##
+_dsl.dsl_sink_num_in_use_max_get.restype = c_uint
+def dsl_sink_num_in_use_max_get():
+    global _dsl
+    result = _dsl.dsl_sink_num_in_use_max_get()
+    return int(result)
+#print(dsl_sink_num_in_use_max_get())
+
+##
+## dsl_sink_num_in_use_max_set()
+##
+_dsl.dsl_sink_num_in_use_max_set.argtypes = [c_uint]
+def dsl_sink_num_in_use_max_set(max):
+    global _dsl
+    result = _dsl.dsl_sink_num_in_use_max_set(max)
+dsl_sink_num_in_use_max_set(20)
+#print(dsl_sink_num_in_use_max_get())
 
 ##
 ## dsl_component_delete()

--- a/src/DslApi.h
+++ b/src/DslApi.h
@@ -661,13 +661,14 @@ DslReturnType dsl_sink_file_encoder_settings_set(const wchar_t* name,
  * @param name unique coomponent name for the new RTSP Sink
  * @param host address for the RTSP Server
  * @param port UDP port number for the RTSP Server
+ * @param port RTSP port number for the RTSP Server
  * @param codec one of DSL_CODEC_H264, DSL_CODEC_H265
  * @param bitrate in bits per second
  * @param interval iframe interval to encode at
  * @return DSL_RESULT_SUCCESS on success, DSL_RESULT_SINK_RESULT on failure
  */
 DslReturnType dsl_sink_rtsp_new(const wchar_t* name, const wchar_t* host, 
-     uint port, uint codec, uint bitrate, uint interval);
+     uint udpPort, uint rtmpPort, uint codec, uint bitrate, uint interval);
 
 /**
  * @brief gets the current codec and video media container formats
@@ -677,7 +678,7 @@ DslReturnType dsl_sink_rtsp_new(const wchar_t* name, const wchar_t* host,
  * @return DSL_RESULT_SUCCESS on success, DSL_RESULT_SINK_RESULT on failure
  */
 DslReturnType dsl_sink_rtsp_server_settings_get(const wchar_t* name,
-    uint* port, uint* codec);
+    uint* udpPort, uint* rtspPort, uint* codec);
 
 /**
  * @brief gets the current bit-rate and interval settings for the named RTSP Sink

--- a/src/DslServices.cpp
+++ b/src/DslServices.cpp
@@ -386,7 +386,7 @@ DslReturnType dsl_sink_file_encoder_settings_set(const wchar_t* name,
 }    
     
 DslReturnType dsl_sink_rtsp_new(const wchar_t* name, const wchar_t* host, 
-     uint port, uint codec, uint bitrate, uint interval)
+     uint udpPort, uint rtspPort, uint codec, uint bitrate, uint interval)
 {
     std::wstring wstrName(name);
     std::string cstrName(wstrName.begin(), wstrName.end());
@@ -394,18 +394,19 @@ DslReturnType dsl_sink_rtsp_new(const wchar_t* name, const wchar_t* host,
     std::string cstrHost(wstrHost.begin(), wstrHost.end());
 
     return DSL::Services::GetServices()->SinkRtspNew(cstrName.c_str(), 
-        cstrHost.c_str(), port, codec, bitrate, interval);
+        cstrHost.c_str(), udpPort, rtspPort, codec, bitrate, interval);
 }     
 
 DslReturnType dsl_sink_rtsp_server_settings_get(const wchar_t* name,
-    uint* port, uint* codec)
+    uint* udpPort, uint* rtspPort, uint* codec)
 {    
     std::wstring wstrName(name);
     std::string cstrName(wstrName.begin(), wstrName.end());
     
     return DSL::Services::GetServices()->SinkRtspServerSettingsGet(cstrName.c_str(), 
-        port, codec);
+        udpPort, rtspPort, codec);
 }    
+
 DslReturnType dsl_sink_rtsp_encoder_settings_get(const wchar_t* name,
     uint* bitrate, uint* interval)
 {
@@ -2043,7 +2044,7 @@ namespace DSL
     }
 
     DslReturnType Services::SinkRtspNew(const char* name, const char* host, 
-            uint port, uint codec, uint bitrate, uint interval)
+            uint udpPort, uint rtspPort, uint codec, uint bitrate, uint interval)
     {
         LOG_FUNC();
         LOCK_MUTEX_FOR_CURRENT_SCOPE(&m_servicesMutex);
@@ -2061,7 +2062,7 @@ namespace DSL
         }
         try
         {
-            m_components[name] = DSL_RTSP_SINK_NEW(name, host, port, codec, bitrate, interval);
+            m_components[name] = DSL_RTSP_SINK_NEW(name, host, udpPort, rtspPort, codec, bitrate, interval);
         }
         catch(...)
         {
@@ -2073,7 +2074,7 @@ namespace DSL
         return DSL_RESULT_SUCCESS;
     }
     
-    DslReturnType Services::SinkRtspServerSettingsGet(const char* name, uint* port, uint* codec)
+    DslReturnType Services::SinkRtspServerSettingsGet(const char* name, uint* udpPort, uint* rtspPort, uint* codec)
     {
         LOG_FUNC();
         LOCK_MUTEX_FOR_CURRENT_SCOPE(&m_servicesMutex);
@@ -2084,7 +2085,7 @@ namespace DSL
             DSL_RTSP_SINK_PTR rtspSinkBintr = 
                 std::dynamic_pointer_cast<RtspSinkBintr>(m_components[name]);
 
-            rtspSinkBintr->GetServerSettings(port, codec);
+            rtspSinkBintr->GetServerSettings(udpPort, rtspPort, codec);
         }
         catch(...)
         {

--- a/src/DslServices.h
+++ b/src/DslServices.h
@@ -134,9 +134,9 @@ namespace DSL {
         DslReturnType SinkFileEncoderSettingsSet(const char* name, uint bitrate, uint interval);
 
         DslReturnType SinkRtspNew(const char* name, const char* host, 
-            uint port, uint codec, uint bit_rate, uint interval);
+            uint updPort, uint rtspPort, uint codec, uint bit_rate, uint interval);
             
-        DslReturnType SinkRtspServerSettingsGet(const char* name, uint* port, uint* codec);
+        DslReturnType SinkRtspServerSettingsGet(const char* name, uint* updPort, uint* rtspPort, uint* codec);
 
         DslReturnType SinkRtspEncoderSettingsGet(const char* name, uint* bitrate, uint* interval);
 

--- a/src/DslSinkBintr.cpp
+++ b/src/DslSinkBintr.cpp
@@ -587,11 +587,12 @@ namespace DSL
         }
         return true;
     }
-    RtspSinkBintr::RtspSinkBintr(const char* sink, const char* host, uint port, uint codec,  
-        uint bitRate, uint interval)
+    RtspSinkBintr::RtspSinkBintr(const char* sink, const char* host, uint udpPort, uint rtspPort,
+         uint codec, uint bitRate, uint interval)
         : SinkBintr(sink)
         , m_host(host)
-        , m_port(port)
+        , m_udpPort(udpPort)
+        , m_rtspPort(rtspPort)
         , m_sync(FALSE)
         , m_async(FALSE)
         , m_codec(codec)
@@ -609,7 +610,7 @@ namespace DSL
         m_pCapsFilter = DSL_ELEMENT_NEW(NVDS_ELEM_CAPS_FILTER, "rtsp-sink-bin-caps-filter");
 
         m_pUdpSink->SetAttribute("host", m_host.c_str());
-        m_pUdpSink->SetAttribute("port", m_port);
+        m_pUdpSink->SetAttribute("port", m_udpPort);
         m_pUdpSink->SetAttribute("sync", m_sync);
         m_pUdpSink->SetAttribute("async", m_async);
 
@@ -644,9 +645,9 @@ namespace DSL
         
         // Setup the GST RTSP Server
         m_pServer = gst_rtsp_server_new();
-        g_object_set(m_pServer, "service", std::to_string(m_port).c_str(), NULL);
+        g_object_set(m_pServer, "service", std::to_string(m_rtspPort).c_str(), NULL);
 
-        std::string udpSrc = "(udpsrc name=pay0 port=" + std::to_string(m_port) + 
+        std::string udpSrc = "(udpsrc name=pay0 port=" + std::to_string(m_udpPort) + 
             " caps=\"application/x-rtp, media=video, clock-rate=90000, encoding-name=" +
             codecString + ", payload=96 \")";
         
@@ -736,11 +737,12 @@ namespace DSL
         m_isLinked = false;
     }
     
-    void RtspSinkBintr::GetServerSettings(uint* port, uint* codec)
+    void RtspSinkBintr::GetServerSettings(uint* udpPort, uint* rtspPort, uint* codec)
     {
         LOG_FUNC();
         
-        *port = m_port;
+        *udpPort = m_udpPort;
+        *rtspPort = m_rtspPort;
         *codec = m_codec;
     }
     

--- a/src/DslSinkBintr.h
+++ b/src/DslSinkBintr.h
@@ -50,9 +50,9 @@ namespace DSL
         new FileSinkBintr(sink, filepath, codec, container, bitRate, interval))
         
     #define DSL_RTSP_SINK_PTR std::shared_ptr<RtspSinkBintr>
-    #define DSL_RTSP_SINK_NEW(sink, host, port, codec, bitRate, interval) \
+    #define DSL_RTSP_SINK_NEW(sink, host, udpPort, rtspPort, codec, bitRate, interval) \
         std::shared_ptr<RtspSinkBintr>( \
-        new RtspSinkBintr(sink, host, port, codec, bitRate, interval))
+        new RtspSinkBintr(sink, host, udpPort, rtspPort, codec, bitRate, interval))
         
 
     class SinkBintr : public Bintr
@@ -311,8 +311,8 @@ namespace DSL
     {
     public: 
     
-        RtspSinkBintr(const char* sink, const char* host, uint port, uint codec, 
-            uint bitRate, uint interval);
+        RtspSinkBintr(const char* sink, const char* host, uint udpPort, uint rtspPort,
+         uint codec, uint bitRate, uint interval);
 
         ~RtspSinkBintr();
   
@@ -331,9 +331,10 @@ namespace DSL
         /**
          * @brief Gets the current codec and media container formats for RtspSinkBintr
          * @param[out] port the current UDP port number for the RTSP Server
+         * @param[out] port the current RTSP port number for the RTSP Server
          * @param[out] codec the current codec format in use [H.264, H.265]
          */ 
-        void GetServerSettings( uint* port, uint* codec);
+        void GetServerSettings(uint* udpPort, uint* rtspPort, uint* codec);
 
         /**
          * @brief Gets the current bit-rate and interval settings for the Encoder in use
@@ -353,7 +354,8 @@ namespace DSL
     private:
 
         std::string m_host;
-        uint m_port;
+        uint m_udpPort;
+        uint m_rtspPort;
         uint m_codec;
         uint m_bitRate;
         uint m_interval;

--- a/test/api/DslPipelinePlayComponentsTest.cpp
+++ b/test/api/DslPipelinePlayComponentsTest.cpp
@@ -676,3 +676,125 @@ SCENARIO( "A new Pipeline with a URI File Source, Tiled Display, and DSL_CODEC_M
         }
     }
 }
+
+SCENARIO( "A new Pipeline with a URI File Source, DSL_CODEC_H264 RTSP Sink, and Tiled Display can play", "[test]" )
+{
+    GIVEN( "A Pipeline, URI source, DSL_CODEC_H264 RTSP Sink, and Tiled Display" ) 
+    {
+        std::wstring sourceName1(L"uri-source");
+        std::wstring uri(L"./test/streams/sample_1080p_h264.mp4");
+        uint cudadecMemType(DSL_CUDADEC_MEMTYPE_DEVICE);
+        uint intrDecode(false);
+        uint dropFrameInterval(0);
+
+        std::wstring tilerName(L"tiler");
+        uint width(1280);
+        uint height(720);
+
+        std::wstring rtspSinkName(L"rtsp-sink");
+        std::wstring host(L"224.224.255.255");
+        uint udpPort(5400);
+        uint rtspPort(8554);
+        uint codec(DSL_CODEC_H264);
+        uint bitrate(4000000);
+        uint interval(0);
+
+        std::wstring pipelineName(L"test-pipeline");
+        
+        REQUIRE( dsl_component_list_size() == 0 );
+
+        REQUIRE( dsl_source_uri_new(sourceName1.c_str(), uri.c_str(), cudadecMemType, 
+            false, intrDecode, dropFrameInterval) == DSL_RESULT_SUCCESS );
+
+        // RTSP sink for this scenario
+        REQUIRE( dsl_sink_rtsp_new(rtspSinkName.c_str(), host.c_str(),
+            udpPort, rtspPort, codec, bitrate, interval) == DSL_RESULT_SUCCESS );
+
+        // new tiler for this scenario
+        REQUIRE( dsl_tiler_new(tilerName.c_str(), width, height) == DSL_RESULT_SUCCESS );
+        
+        const wchar_t* components[] = {L"uri-source", L"tiler", L"rtsp-sink", NULL};
+        
+        WHEN( "When the Pipeline is Assembled" ) 
+        {
+            REQUIRE( dsl_pipeline_new(pipelineName.c_str()) == DSL_RESULT_SUCCESS );
+        
+            REQUIRE( dsl_pipeline_component_add_many(pipelineName.c_str(), components) == DSL_RESULT_SUCCESS );
+
+            THEN( "Pipeline is Able to LinkAll and Play" )
+            {
+                bool currIsClockEnabled(false);
+                
+                REQUIRE( dsl_pipeline_play(pipelineName.c_str()) == DSL_RESULT_SUCCESS );
+                std::this_thread::sleep_for(std::chrono::milliseconds(10000));
+                REQUIRE( dsl_pipeline_stop(pipelineName.c_str()) == DSL_RESULT_SUCCESS );
+
+                REQUIRE( dsl_pipeline_delete_all() == DSL_RESULT_SUCCESS );
+                REQUIRE( dsl_pipeline_list_size() == 0 );
+                REQUIRE( dsl_component_delete_all() == DSL_RESULT_SUCCESS );
+                REQUIRE( dsl_component_list_size() == 0 );
+            }
+        }
+    }
+}
+
+SCENARIO( "A new Pipeline with a URI File Source, DSL_CODEC_H265 RTSP Sink, and Tiled Display can play", "[test]" )
+{
+    GIVEN( "A Pipeline, URI source, DSL_CODEC_H265 RTSP Sink, and Tiled Display" ) 
+    {
+        std::wstring sourceName1(L"uri-source");
+        std::wstring uri(L"./test/streams/sample_1080p_h264.mp4");
+        uint cudadecMemType(DSL_CUDADEC_MEMTYPE_DEVICE);
+        uint intrDecode(false);
+        uint dropFrameInterval(0);
+
+        std::wstring tilerName(L"tiler");
+        uint width(1280);
+        uint height(720);
+
+        std::wstring rtspSinkName(L"rtsp-sink");
+        std::wstring host(L"224.224.255.255");
+        uint udpPort(5400);
+        uint rtspPort(8554);
+        uint codec(DSL_CODEC_H265);
+        uint bitrate(4000000);
+        uint interval(0);
+
+        std::wstring pipelineName(L"test-pipeline");
+        
+        REQUIRE( dsl_component_list_size() == 0 );
+
+        REQUIRE( dsl_source_uri_new(sourceName1.c_str(), uri.c_str(), cudadecMemType, 
+            false, intrDecode, dropFrameInterval) == DSL_RESULT_SUCCESS );
+
+        // RTSP sink for this scenario
+        REQUIRE( dsl_sink_rtsp_new(rtspSinkName.c_str(), host.c_str(),
+            udpPort, rtspPort, codec, bitrate, interval) == DSL_RESULT_SUCCESS );
+
+        // new tiler for this scenario
+        REQUIRE( dsl_tiler_new(tilerName.c_str(), width, height) == DSL_RESULT_SUCCESS );
+        
+        const wchar_t* components[] = {L"uri-source", L"tiler", L"rtsp-sink", NULL};
+        
+        WHEN( "When the Pipeline is Assembled" ) 
+        {
+            REQUIRE( dsl_pipeline_new(pipelineName.c_str()) == DSL_RESULT_SUCCESS );
+        
+            REQUIRE( dsl_pipeline_component_add_many(pipelineName.c_str(), components) == DSL_RESULT_SUCCESS );
+
+            THEN( "Pipeline is Able to LinkAll and Play" )
+            {
+                bool currIsClockEnabled(false);
+                
+                REQUIRE( dsl_pipeline_play(pipelineName.c_str()) == DSL_RESULT_SUCCESS );
+                std::this_thread::sleep_for(std::chrono::milliseconds(10000));
+                REQUIRE( dsl_pipeline_stop(pipelineName.c_str()) == DSL_RESULT_SUCCESS );
+
+                REQUIRE( dsl_pipeline_delete_all() == DSL_RESULT_SUCCESS );
+                REQUIRE( dsl_pipeline_list_size() == 0 );
+                REQUIRE( dsl_component_delete_all() == DSL_RESULT_SUCCESS );
+                REQUIRE( dsl_component_list_size() == 0 );
+            }
+        }
+    }
+}

--- a/test/api/DslSinkApiTest.cpp
+++ b/test/api/DslSinkApiTest.cpp
@@ -503,7 +503,8 @@ SCENARIO( "The Components container is updated correctly on new DSL_CODEC_H264 R
     {
         std::wstring rtspSinkName(L"rtsp-sink");
         std::wstring host(L"224.224.255.255");
-        uint port(8080);
+        uint udpPort(5400);
+        uint rtspPort(8554);
         uint codec(DSL_CODEC_H264);
         uint bitrate(4000000);
         uint interval(0);
@@ -513,13 +514,14 @@ SCENARIO( "The Components container is updated correctly on new DSL_CODEC_H264 R
         WHEN( "A new RTSP Sink is created" ) 
         {
             REQUIRE( dsl_sink_rtsp_new(rtspSinkName.c_str(), host.c_str(),
-                port, codec, bitrate, interval) == DSL_RESULT_SUCCESS );
+                udpPort, rtspPort, codec, bitrate, interval) == DSL_RESULT_SUCCESS );
 
             THEN( "The list size is updated correctly" ) 
             {
-                uint retPort(0), retCodec(0);
-                dsl_sink_rtsp_server_settings_get(rtspSinkName.c_str(), &retPort, &retCodec);
-                REQUIRE( retPort == port );
+                uint retUdpPort(0), retRtspPort(0), retCodec(0);
+                dsl_sink_rtsp_server_settings_get(rtspSinkName.c_str(), &retUdpPort, &retRtspPort, &retCodec);
+                REQUIRE( retUdpPort == udpPort );
+                REQUIRE( retRtspPort == rtspPort );
                 REQUIRE( retCodec == codec );
                 REQUIRE( dsl_component_list_size() == 1 );
             }
@@ -534,14 +536,15 @@ SCENARIO( "The Components container is updated correctly on DSL_CODEC_H264 RTSP 
     {
         std::wstring rtspSinkName(L"rtsp-sink");
         std::wstring host(L"224.224.255.255");
-        uint port(8080);
+        uint udpPort(5400);
+        uint rtspPort(8554);
         uint codec(DSL_CODEC_H264);
         uint bitrate(4000000);
         uint interval(0);
 
         REQUIRE( dsl_component_list_size() == 0 );
         REQUIRE( dsl_sink_rtsp_new(rtspSinkName.c_str(), host.c_str(),
-            port, codec, bitrate, interval) == DSL_RESULT_SUCCESS );
+            udpPort, rtspPort, codec, bitrate, interval) == DSL_RESULT_SUCCESS );
 
         WHEN( "A new RTSP Sink is deleted" ) 
         {
@@ -561,7 +564,8 @@ SCENARIO( "The Components container is updated correctly on new DSL_CODEC_H265 R
     {
         std::wstring rtspSinkName(L"rtsp-sink");
         std::wstring host(L"224.224.255.255");
-        uint port(8080);
+        uint udpPort(5400);
+        uint rtspPort(8554);
         uint codec(DSL_CODEC_H265);
         uint bitrate(4000000);
         uint interval(0);
@@ -571,13 +575,14 @@ SCENARIO( "The Components container is updated correctly on new DSL_CODEC_H265 R
         WHEN( "A new RTSP Sink is created" ) 
         {
             REQUIRE( dsl_sink_rtsp_new(rtspSinkName.c_str(), host.c_str(),
-                port, codec, bitrate, interval) == DSL_RESULT_SUCCESS );
+                udpPort, rtspPort, codec, bitrate, interval) == DSL_RESULT_SUCCESS );
 
             THEN( "The list size is updated correctly" ) 
             {
-                uint retPort(0), retCodec(0);
-                dsl_sink_rtsp_server_settings_get(rtspSinkName.c_str(), &retPort, &retCodec);
-                REQUIRE( retPort == port );
+                uint retUdpPort(0), retRtspPort(0), retCodec(0);
+                dsl_sink_rtsp_server_settings_get(rtspSinkName.c_str(), &retUdpPort, &retRtspPort, &retCodec);
+                REQUIRE( retUdpPort == udpPort );
+                REQUIRE( retRtspPort == rtspPort );
                 REQUIRE( retCodec == codec );
                 REQUIRE( dsl_component_list_size() == 1 );
             }
@@ -592,14 +597,15 @@ SCENARIO( "The Components container is updated correctly on DSL_CODEC_H265 RTSP 
     {
         std::wstring rtspSinkName(L"rtsp-sink");
         std::wstring host(L"224.224.255.255");
-        uint port(8080);
+        uint udpPort(5400);
+        uint rtspPort(8554);
         uint codec(DSL_CODEC_H265);
         uint bitrate(4000000);
         uint interval(0);
 
         REQUIRE( dsl_component_list_size() == 0 );
         REQUIRE( dsl_sink_rtsp_new(rtspSinkName.c_str(), host.c_str(),
-            port, codec, bitrate, interval) == DSL_RESULT_SUCCESS );
+            udpPort, rtspPort, codec, bitrate, interval) == DSL_RESULT_SUCCESS );
 
         WHEN( "A new RTSP Sink is deleted" ) 
         {
@@ -618,13 +624,14 @@ SCENARIO( "An RTSP Sink's Encoder settings can be updated", "[rtsp-sink-api]" )
     {
         std::wstring rtspSinkName(L"rtsp-sink");
         std::wstring host(L"224.224.255.255");
-        uint port(8080);
+        uint udpPort(5400);
+        uint rtspPort(8554);
         uint codec(DSL_CODEC_H265);
         uint initBitrate(4000000);
         uint initInterval(0);
 
         REQUIRE( dsl_sink_rtsp_new(rtspSinkName.c_str(), host.c_str(),
-            port, codec, initBitrate, initInterval) == DSL_RESULT_SUCCESS );
+            udpPort, rtspPort, codec, initBitrate, initInterval) == DSL_RESULT_SUCCESS );
             
         uint currBitrate(0);
         uint currInterval(0);

--- a/test/unit/DslSinkUnitTest.cpp
+++ b/test/unit/DslSinkUnitTest.cpp
@@ -658,7 +658,8 @@ SCENARIO( "A new DSL_CODEC_H264 RtspSinkBintr is created correctly",  "[RtspSink
     {
         std::string sinkName("rtsp-sink");
         std::string host("224.224.255.255");
-        uint port(8080);
+        uint udpPort(5400);
+        uint rtspPort(8554);
         uint codec(DSL_CODEC_H264);
         uint bitrate(4000000);
         uint interval(0);
@@ -666,13 +667,14 @@ SCENARIO( "A new DSL_CODEC_H264 RtspSinkBintr is created correctly",  "[RtspSink
         WHEN( "The DSL_CODEC_H264 RtspSinkBintr is created " )
         {
             DSL_RTSP_SINK_PTR pSinkBintr = 
-                DSL_RTSP_SINK_NEW(sinkName.c_str(), host.c_str(), port, codec, bitrate, interval);
+                DSL_RTSP_SINK_NEW(sinkName.c_str(), host.c_str(), udpPort, rtspPort, codec, bitrate, interval);
             
             THEN( "The correct attribute values are returned" )
             {
-                uint retPort(0), retCodec(0);
-                pSinkBintr->GetServerSettings(&retPort, &retCodec);
-                REQUIRE( retPort == port);
+                uint retUdpPort(0), retRtspPort(0), retCodec(0);
+                pSinkBintr->GetServerSettings(&retUdpPort, &retRtspPort, &retCodec);
+                REQUIRE( retUdpPort == udpPort );
+                REQUIRE( retRtspPort == rtspPort );
                 REQUIRE( retCodec == codec );
                 REQUIRE( pSinkBintr->IsWindowCapable() == false );
             }
@@ -686,13 +688,14 @@ SCENARIO( "A new DSL_CODEC_H264 RtspSinkBintr can LinkAll Child Elementrs", "[Rt
     {
         std::string sinkName("rtsp-sink");
         std::string host("224.224.255.255");
-        uint port(8080);
+        uint udpPort(5400);
+        uint rtspPort(8554);
         uint codec(DSL_CODEC_H264);
         uint bitrate(4000000);
         uint interval(0);
 
         DSL_RTSP_SINK_PTR pSinkBintr = 
-            DSL_RTSP_SINK_NEW(sinkName.c_str(), host.c_str(), port, codec, bitrate, interval);
+            DSL_RTSP_SINK_NEW(sinkName.c_str(), host.c_str(), udpPort, rtspPort, codec, bitrate, interval);
 
         REQUIRE( pSinkBintr->IsLinked() == false );
 
@@ -714,13 +717,14 @@ SCENARIO( "A Linked DSL_CODEC_H264 RtspSinkBintr can UnlinkAll Child Elementrs",
     {
         std::string sinkName("rtsp-sink");
         std::string host("224.224.255.255");
-        uint port(8080);
+        uint udpPort(5400);
+        uint rtspPort(8554);
         uint codec(DSL_CODEC_H264);
         uint bitrate(4000000);
         uint interval(0);
 
         DSL_RTSP_SINK_PTR pSinkBintr = 
-            DSL_RTSP_SINK_NEW(sinkName.c_str(), host.c_str(), port, codec, bitrate, interval);
+            DSL_RTSP_SINK_NEW(sinkName.c_str(), host.c_str(), udpPort, rtspPort, codec, bitrate, interval);
 
         REQUIRE( pSinkBintr->IsLinked() == false );
         REQUIRE( pSinkBintr->LinkAll() == true );
@@ -743,7 +747,8 @@ SCENARIO( "A new DSL_CODEC_H265 RtspSinkBintr is created correctly",  "[RtspSink
     {
         std::string sinkName("rtsp-sink");
         std::string host("224.224.255.255");
-        uint port(8080);
+        uint udpPort(5400);
+        uint rtspPort(8554);
         uint codec(DSL_CODEC_H265);
         uint bitrate(4000000);
         uint interval(0);
@@ -751,13 +756,14 @@ SCENARIO( "A new DSL_CODEC_H265 RtspSinkBintr is created correctly",  "[RtspSink
         WHEN( "The DSL_CODEC_H265 RtspSinkBintr is created " )
         {
             DSL_RTSP_SINK_PTR pSinkBintr = 
-                DSL_RTSP_SINK_NEW(sinkName.c_str(), host.c_str(), port, codec, bitrate, interval);
+                DSL_RTSP_SINK_NEW(sinkName.c_str(), host.c_str(), udpPort, rtspPort, codec, bitrate, interval);
             
             THEN( "The correct attribute values are returned" )
             {
-                uint retPort(0), retCodec(0);
-                pSinkBintr->GetServerSettings(&retPort, &retCodec);
-                REQUIRE( retPort == port);
+                uint retUdpPort(0), retRtspPort(0), retCodec(0);
+                pSinkBintr->GetServerSettings(&retUdpPort, &retRtspPort, &retCodec);
+                REQUIRE( retUdpPort == udpPort);
+                REQUIRE( retRtspPort == rtspPort);
                 REQUIRE( retCodec == codec );
                 REQUIRE( pSinkBintr->IsWindowCapable() == false );
             }
@@ -771,13 +777,14 @@ SCENARIO( "A new DSL_CODEC_H265 RtspSinkBintr can LinkAll Child Elementrs", "[Rt
     {
         std::string sinkName("rtsp-sink");
         std::string host("224.224.255.255");
-        uint port(8080);
+        uint udpPort(5400);
+        uint rtspPort(8554);
         uint codec(DSL_CODEC_H265);
         uint bitrate(4000000);
         uint interval(0);
 
         DSL_RTSP_SINK_PTR pSinkBintr = 
-            DSL_RTSP_SINK_NEW(sinkName.c_str(), host.c_str(), port, codec, bitrate, interval);
+            DSL_RTSP_SINK_NEW(sinkName.c_str(), host.c_str(), udpPort, rtspPort, codec, bitrate, interval);
 
         REQUIRE( pSinkBintr->IsLinked() == false );
 
@@ -799,13 +806,14 @@ SCENARIO( "A Linked DSL_CODEC_H265 RtspSinkBintr can UnlinkAll Child Elementrs",
     {
         std::string sinkName("rtsp-sink");
         std::string host("224.224.255.255");
-        uint port(8080);
+        uint udpPort(5400);
+        uint rtspPort(8554);
         uint codec(DSL_CODEC_H265);
         uint bitrate(4000000);
         uint interval(0);
 
         DSL_RTSP_SINK_PTR pSinkBintr = 
-            DSL_RTSP_SINK_NEW(sinkName.c_str(), host.c_str(), port, codec, bitrate, interval);
+            DSL_RTSP_SINK_NEW(sinkName.c_str(), host.c_str(), udpPort, rtspPort, codec, bitrate, interval);
 
         REQUIRE( pSinkBintr->IsLinked() == false );
         REQUIRE( pSinkBintr->LinkAll() == true );


### PR DESCRIPTION
@Sscsmatrix this completes the RTSP sink,  I don't have an example script yet, but the constructor to use is

```Python
dsl_sink_rtsp_new("rtsp-sink", "224.224.255.255", 5400, 8554, DSL_CODEC_H265, 4000000, 0)
```
Using both an RTSP Source and Sink, you should be able to connect to your RaspberryPi server, and then connect the DSL server with your laptop, I would think.  