### PR TITLE
Added latency paramter for RTSP source

### DIFF
--- a/docs/api-source.md
+++ b/docs/api-source.md
@@ -172,7 +172,7 @@ retval = dsl_source_uri_new('dsl_source_uri_new', '../../test/streams/sample_108
 ### *dsl_source_rtsp_new*
 ```C++
 DslReturnType dsl_source_rtsp_new(const wchar_t* name, const wchar_t* uri, uint protocol,
-    uint cudadec_mem_type, uint intra_decode, uint drop_frame_interval);
+    uint cudadec_mem_type, uint intra_decode, uint drop_frame_interval, uint latency);
 ```
 
 This service creates a new, uniquely named URI Source component

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -289,8 +289,8 @@ The first step is to create the two RTMP Sources - and the two File Sinks that w
 
 # Create two live RTSP Sources
 
-retval = dsl_source_rtsp_new('src-1', rtsp_uri_1, DSL_RTP_ALL, DSL_CUDADEC_MEMTYPE_DEVICE, True, 0)
-retval = dsl_source_rtsp_new('src-2', rtsp_uri_2, DSL_RTP_ALL, DSL_CUDADEC_MEMTYPE_DEVICE, True, 0)
+retval = dsl_source_rtsp_new('src-1', rtsp_uri_1, DSL_RTP_ALL, DSL_CUDADEC_MEMTYPE_DEVICE, True, 0, 100)
+retval = dsl_source_rtsp_new('src-2', rtsp_uri_2, DSL_RTP_ALL, DSL_CUDADEC_MEMTYPE_DEVICE, True, 0, 100)
 
 # Create two File Sinks for Branch 2, one for each source
 
@@ -363,8 +363,8 @@ retval = dsl_pipeline_new_component_add_many('pipeline', ['src-1', 'src-2', 'spl
 # NOTE: this example assumes that all return values are checked for DSL_RESULT_SUCCESS before proceeding
 
 # Create two live RTSP Sources
-retval = dsl_source_rtsp_new('src-1', rtsp_uri_1, DSL_RTP_ALL, DSL_CUDADEC_MEMTYPE_DEVICE, True, 0)
-retval = dsl_source_rtsp_new('src-2', rtsp_uri_2, DSL_RTP_ALL, DSL_CUDADEC_MEMTYPE_DEVICE, True, 0)
+retval = dsl_source_rtsp_new('src-1', rtsp_uri_1, DSL_RTP_ALL, DSL_CUDADEC_MEMTYPE_DEVICE, True, 0, 100)
+retval = dsl_source_rtsp_new('src-2', rtsp_uri_2, DSL_RTP_ALL, DSL_CUDADEC_MEMTYPE_DEVICE, True, 0, 100)
 
 # Create two File Sinks, one for each source
 retval = dsl_sink_file_new('file-sink1', './src-1.mp4', DSL_CODEC_H264, DSL_CONTAINER_MPEG, 200000, 0)

--- a/dsl.py
+++ b/dsl.py
@@ -1051,11 +1051,11 @@ def dsl_source_uri_new(name, uri, is_live, cudadec_mem_type, intra_decode, drop_
 ##
 ## dsl_source_rtsp_new()
 ##
-_dsl.dsl_source_rtsp_new.argtypes = [c_wchar_p, c_wchar_p, c_uint, c_uint, c_uint, c_uint]
+_dsl.dsl_source_rtsp_new.argtypes = [c_wchar_p, c_wchar_p, c_uint, c_uint, c_uint, c_uint, c_uint]
 _dsl.dsl_source_rtsp_new.restype = c_uint
-def dsl_source_rtsp_new(name, uri, protocol, cudadec_mem_type, intra_decode, drop_frame_interval):
+def dsl_source_rtsp_new(name, uri, protocol, cudadec_mem_type, intra_decode, drop_frame_interval, latency):
     global _dsl
-    result = _dsl.dsl_source_rtsp_new(name, uri, protocol, cudadec_mem_type, intra_decode, drop_frame_interval)
+    result = _dsl.dsl_source_rtsp_new(name, uri, protocol, cudadec_mem_type, intra_decode, drop_frame_interval, latency)
     return int(result)
 
 ##

--- a/examples/python/1rtsp_1csi_live_pgie_tiler_osd_window.py
+++ b/examples/python/1rtsp_1csi_live_pgie_tiler_osd_window.py
@@ -49,7 +49,7 @@ def main(args):
     while True:
 
         # New RTSP Live Camera Source
-        retval = dsl_source_rtsp_new('rtsp-source', rtsp_uri, DSL_RTP_ALL, DSL_CUDADEC_MEMTYPE_DEVICE, False, 1)
+        retval = dsl_source_rtsp_new('rtsp-source', rtsp_uri, DSL_RTP_ALL, DSL_CUDADEC_MEMTYPE_DEVICE, False, 1, 100)
         if retval != DSL_RETURN_SUCCESS:
             break
 

--- a/examples/python/ode_occurrence_rtsp_start_record_tap_action.py
+++ b/examples/python/ode_occurrence_rtsp_start_record_tap_action.py
@@ -225,7 +225,7 @@ def main(args):
         # Create the remaining Pipeline components
         
         # New RTSP Live Camera Source
-        retval = dsl_source_rtsp_new('rtsp-source', rtsp_uri, DSL_RTP_ALL, DSL_CUDADEC_MEMTYPE_DEVICE, False, 0)
+        retval = dsl_source_rtsp_new('rtsp-source', rtsp_uri, DSL_RTP_ALL, DSL_CUDADEC_MEMTYPE_DEVICE, False, 0, 100)
         if retval != DSL_RETURN_SUCCESS:
             break
 

--- a/src/DslApi.cpp
+++ b/src/DslApi.cpp
@@ -1047,7 +1047,7 @@ DslReturnType dsl_source_uri_new(const wchar_t* name, const wchar_t* uri,
 }
 
 DslReturnType dsl_source_rtsp_new(const wchar_t* name, const wchar_t* uri,
-    uint protocol, uint cudadec_mem_type, uint intra_decode, uint dropFrameInterval)
+    uint protocol, uint cudadec_mem_type, uint intra_decode, uint dropFrameInterval, uint latency)
 {
     std::wstring wstrName(name);
     std::string cstrName(wstrName.begin(), wstrName.end());
@@ -1055,7 +1055,7 @@ DslReturnType dsl_source_rtsp_new(const wchar_t* name, const wchar_t* uri,
     std::string cstrUri(wstrUri.begin(), wstrUri.end());
 
     return DSL::Services::GetServices()->SourceRtspNew(cstrName.c_str(), cstrUri.c_str(), 
-        protocol, cudadec_mem_type, intra_decode, dropFrameInterval);
+        protocol, cudadec_mem_type, intra_decode, dropFrameInterval, latency);
 }
 
 DslReturnType dsl_source_dimensions_get(const wchar_t* name, uint* width, uint* height)

--- a/src/DslApi.h
+++ b/src/DslApi.h
@@ -1456,11 +1456,13 @@ DslReturnType dsl_source_uri_new(const wchar_t* name, const wchar_t* uri, boolea
  * @param[in] name Unique Resource Identifier (file or live)
  * @param[in] protocol one of the constant protocol values [ DSL_RTP_TCP | DSL_RTP_ALL ]
  * @param[in] cudadec_mem_type, use DSL_CUDADEC_MEMORY_TYPE_<type>
- * @param[in] 
+ * @param[in] intra_decode
+ * @param[in] drop_frame_interval
+ * @param[in] latency in milliseconds
  * @return DSL_RESULT_SUCCESS on success, DSL_RESULT_SOURCE_RESULT otherwise.
  */
 DslReturnType dsl_source_rtsp_new(const wchar_t* name, const wchar_t* uri, uint protocol,
-    uint cudadec_mem_type, uint intra_decode, uint drop_frame_interval);
+    uint cudadec_mem_type, uint intra_decode, uint drop_frame_interval, uint latency);
 
 /**
  * @brief returns the frame rate of the name source as a fraction

--- a/src/DslServices.cpp
+++ b/src/DslServices.cpp
@@ -2868,7 +2868,7 @@ namespace DSL
     }
 
     DslReturnType Services::SourceRtspNew(const char* name, const char* uri, 
-        uint protocol, uint cudadecMemType, uint intraDecode, uint dropFrameInterval)
+        uint protocol, uint cudadecMemType, uint intraDecode, uint dropFrameInterval, uint latency)
     {
         LOG_FUNC();
         LOCK_MUTEX_FOR_CURRENT_SCOPE(&m_servicesMutex);
@@ -2882,7 +2882,7 @@ namespace DSL
                 return DSL_RESULT_SOURCE_NAME_NOT_UNIQUE;
             }
             m_components[name] = DSL_RTSP_SOURCE_NEW(
-                name, uri, protocol, cudadecMemType, intraDecode, dropFrameInterval);
+                name, uri, protocol, cudadecMemType, intraDecode, dropFrameInterval, latency);
 
             LOG_INFO("New RTSP Source '" << name << "' created successfully");
 

--- a/src/DslServices.h
+++ b/src/DslServices.h
@@ -263,7 +263,7 @@ namespace DSL {
             boolean isLive, uint cudadecMemType, uint intraDecode, uint dropFrameInterval);
             
         DslReturnType SourceRtspNew(const char* name, const char* uri, 
-            uint protocol, uint cudadecMemType, uint intraDecode, uint dropFrameInterval);
+            uint protocol, uint cudadecMemType, uint intraDecode, uint dropFrameInterval, uint latency);
             
         DslReturnType SourceDimensionsGet(const char* name, uint* width, uint* height);
         

--- a/src/DslSourceBintr.cpp
+++ b/src/DslSourceBintr.cpp
@@ -795,12 +795,16 @@ namespace DSL
     //*********************************************************************************
     
     RtspSourceBintr::RtspSourceBintr(const char* name, const char* uri, uint protocol,
-        uint cudadecMemType, uint intraDecode, uint dropFrameInterval)
+        uint cudadecMemType, uint intraDecode, uint dropFrameInterval, uint latency)
         : DecodeSourceBintr(name, "rtspsrc", uri, true, cudadecMemType, intraDecode, dropFrameInterval)
         , m_rtpProtocols(protocol)
     {
         LOG_FUNC();
         
+        // Set RTSP latency
+        m_latency = latency;
+        LOG_DEBUG("Setting latency to '" << latency << "' for RtspSourceBintr '" << m_name << "'");
+
         // New RTSP Specific Elementrs for this Source
         m_pPreDecodeTee = DSL_ELEMENT_NEW(NVDS_ELEM_TEE, "pre-decode-tee");
         m_pPreDecodeQueue = DSL_ELEMENT_NEW(NVDS_ELEM_QUEUE, "pre-decode-queue");

--- a/src/DslSourceBintr.h
+++ b/src/DslSourceBintr.h
@@ -57,8 +57,8 @@ namespace DSL
         std::shared_ptr<UriSourceBintr>(new UriSourceBintr(name, uri, isLive, cudadecMemType, intraDecode, dropFrameInterval))
         
     #define DSL_RTSP_SOURCE_PTR std::shared_ptr<RtspSourceBintr>
-    #define DSL_RTSP_SOURCE_NEW(name, uri, protocol, cudadecMemType, intraDecode, dropFrameInterval) \
-        std::shared_ptr<RtspSourceBintr>(new RtspSourceBintr(name, uri, protocol, cudadecMemType, intraDecode, dropFrameInterval))
+    #define DSL_RTSP_SOURCE_NEW(name, uri, protocol, cudadecMemType, intraDecode, dropFrameInterval, latency) \
+        std::shared_ptr<RtspSourceBintr>(new RtspSourceBintr(name, uri, protocol, cudadecMemType, intraDecode, dropFrameInterval, latency))
 
     /**
      * @class SourceBintr
@@ -444,7 +444,7 @@ namespace DSL
     public: 
     
         RtspSourceBintr(const char* name, const char* uri, uint protocol,
-            uint cudadecMemType, uint intraDecode, uint dropFrameInterval);
+            uint cudadecMemType, uint intraDecode, uint dropFrameInterval, uint latency);
 
         ~RtspSourceBintr();
 

--- a/test/api/dsl-ctypes-check.py
+++ b/test/api/dsl-ctypes-check.py
@@ -29,7 +29,7 @@ print(dsl_component_delete("uri-source"))
 ## dsl_source_rtsp_new()
 ##
 #print("dsl_source_rtsp_new")
-#print(dsl_source_rtsp_new("rtsp-source", "???????", DSL_RTP_ALL, 0, 0, 0))
+#print(dsl_source_rtsp_new("rtsp-source", "???????", DSL_RTP_ALL, 0, 0, 0, 100))
 #print(dsl_component_delete("rtsp-source"))
 
 ##

--- a/test/unit/DslSourceUnitTest.cpp
+++ b/test/unit/DslSourceUnitTest.cpp
@@ -577,11 +577,12 @@ SCENARIO( "A new RtspSourceBintr is created correctly",  "[UriSourceBintr]" )
         uint cudadecMemType(DSL_CUDADEC_MEMTYPE_DEVICE);
         uint intrDecode(true);
         uint dropFrameInterval(2);
+        uint latency(100);
 
         WHEN( "The RtspSourceBintr is created " )
         {
             DSL_RTSP_SOURCE_PTR pSourceBintr = DSL_RTSP_SOURCE_NEW(
-                sourceName.c_str(), uri.c_str(), DSL_RTP_ALL, cudadecMemType, intrDecode, dropFrameInterval);
+                sourceName.c_str(), uri.c_str(), DSL_RTP_ALL, cudadecMemType, intrDecode, dropFrameInterval, latency);
 
             THEN( "All memeber variables are initialized correctly" )
             {
@@ -618,9 +619,10 @@ SCENARIO( "A RtspSourceBintr can Get and Set its GPU ID",  "[RtspSourceBintr]" )
         uint cudadecMemType(DSL_CUDADEC_MEMTYPE_DEVICE);
         uint intrDecode(true);
         uint dropFrameInterval(2);
+        uint latency(100);
         
         DSL_RTSP_SOURCE_PTR pRtspSourceBintr = DSL_RTSP_SOURCE_NEW(
-            sourceName.c_str(), uri.c_str(), DSL_RTP_ALL, cudadecMemType, intrDecode, dropFrameInterval);
+            sourceName.c_str(), uri.c_str(), DSL_RTP_ALL, cudadecMemType, intrDecode, dropFrameInterval, latency);
 
         uint GPUID0(0);
         uint GPUID1(1);


### PR DESCRIPTION
The default latency for SourceBintr is 100ms.  For RTSP source a user might generally want to specify the latency per source.  This PR adds the latency parameter.

Note, the default latency for `rtspsrc` element is 2000ms (see: https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-good/html/gst-plugins-good-plugins-rtspsrc.html#GstRTSPSrc--latency).