### PR TITLE
VSCode configurations C++/Python linting, building and debugging

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+# See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+# See: https://code.visualstudio.com/docs/cpp/cpp-ide#_code-formatting
+
+# Copied from "Visual Studio" style
+BasedOnStyle: LLVM
+UseTab: Never
+IndentWidth: 4
+TabWidth: 4
+BreakBeforeBraces: Allman
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+ColumnLimit: 0
+
+# Custom
+AccessModifierOffset: -4
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: DontAlign
+AllowShortBlocksOnASingleLine: Never
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeComma
+DerivePointerAlignment: false
+NamespaceIndentation: All
+PointerAlignment: Left

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,23 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "/usr/lib/aarch64-linux-gnu/glib-2.0/include",
+                "/usr/include/glib-2.0/**",
+                "/usr/include/gstreamer-1.0/**",
+                "/usr/include/opencv4/**",
+                "/usr/local/cuda-10.2/targets/aarch64-linux/include",
+                "/opt/nvidia/deepstream/deepstream-5.0/sources/includes",
+                "/opt/nvidia/deepstream/deepstream-5.0/sources/apps/apps-common/includes",
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "gnu11",
+            "cppStandard": "gnu++14",
+            "intelliSenseMode": "clang-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,47 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/examples/python",
+            "env": {
+                "DISPLAY": ":1"
+            }
+        },
+        {
+            "name": "CPP: Current Python File",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "/usr/bin/python3",
+            "args": [
+                "${file}"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/examples/python",
+            "environment": [
+                {
+                    "name": "DISPLAY",
+                    "value": ":1"
+                }
+            ],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "build:debug",
+            "miDebuggerPath": "/usr/bin/gdb"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "C_Cpp.clang_format_fallbackStyle": "Visual Studio"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,10 @@
     "C_Cpp.clang_format_fallbackStyle": "Visual Studio",
     "python.pythonPath": "~/.virtualenvs/dsl/bin/python",
     "python.linting.pylintEnabled": true,
+    "python.linting.pylintArgs": [
+        "--max-line-length",
+        "120"
+    ],
     "python.formatting.provider": "autopep8",
     "python.formatting.autopep8Args": [
         "--max-line-length",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-    "C_Cpp.clang_format_fallbackStyle": "Visual Studio"
+    "C_Cpp.clang_format_fallbackStyle": "Visual Studio",
+    "python.pythonPath": "~/.virtualenvs/dsl/bin/python",
+    "python.linting.pylintEnabled": true,
+    "python.formatting.provider": "autopep8",
+    "python.formatting.autopep8Args": [
+        "--max-line-length",
+        "120",
+        "--ignore",
+        "E402"
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,34 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "shell",
+			"label": "build:debug",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"command": "make debug && make so_lib",
+			"args": [],
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"problemMatcher": [
+				"$gcc"
+			]
+		},
+		{
+			"type": "shell",
+			"label": "build:test",
+			"group": "build",
+			"command": "make && make lib",
+			"args": [],
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"problemMatcher": [
+				"$gcc"
+			]
+		}
+	]
+}

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,6 @@ endif
 CFLAGS+= -I$(INC_INSTALL_DIR) \
     -I$(SRC_INSTALL_DIR)/apps/apps-common/includes \
     -I/opt/include \
-	-I/opt/nvidia/deepstream/deepstream-4.0/sources/includes \
 	-I/usr/include \
 	-I/usr/include/gstreamer-$(GS_VERSION) \
 	-I/usr/include/glib-$(GLIB_VERSION) \
@@ -113,6 +112,9 @@ LIBS+= `pkg-config --libs $(PKGS)`
 
 all: $(APP)
 
+debug: CFLAGS += -DDEBUG -g
+debug: $(APP)
+
 PCH_INC=./src/Dsl.h
 PCH_OUT=./src/Dsl.h.gch
 $(PCH_OUT): $(PCH_INC) Makefile
@@ -133,6 +135,7 @@ lib:
 	
 so_lib:
 	$(CXX) -shared $(OBJS) -o dsl-lib.so $(LIBS) 
+	cp dsl-lib.so examples/python/
 
 clean:
 	rm -rf $(OBJS) $(APP) dsl-lib.a dsl-lib.so $(PCH_OUT)


### PR DESCRIPTION
VSCode C++ Extension v0.30.0-insiders4 required for ARM64 support using Remote Extensions

Setup
- Install VSCode
- Setup Remote SSH to Jetson Nano (https://code.visualstudio.com/docs/remote/ssh)
- Install Python Extension (ms-python.python) on remote
- Install C++ Extension (ms-vscode.cpptools) on remote

To build C++ DSL lib
- `Ctrl+Shift+Build` 

To debug Python:
- Open Python file
- Place breakpoint
- Choose `Python: Current File` config (`Ctrl+Shift+D` - choose from dropdown)
- Press F5

To debug C++ using Python file:
- Place breakpoints in C++ files
- Open Python file
- Choose `CPP: Current Python File` config (`Ctrl+Shift+D` - choose from dropdown)
- Press F5
